### PR TITLE
Remove server side includes from reserves

### DIFF
--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -3,16 +3,6 @@ module AssetsHelper
   include HesburghAssets::AssetsHelper
 
 
-  # Includes the relevant library SSI file from http://library.nd.edu/ssi/<filename>.shtml
-  def include_ssi(filepath)
-    if Rails.env == 'test'
-      "SSI INCLUDE !!!"
-    else
-      render :partial => "/layouts/hesburgh_assets/include_ssi", :locals => {:filepath => filepath}
-    end
-  end
-
-
   def breadcrumb(*crumbs)
     crumbs.unshift(link_to("Home", root_path()))
     content_for(:breadcrumb, raw(crumbs.join(" &gt; ")))

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -94,8 +94,6 @@
 
       </div>
 
-      <%= include_ssi("/local_ssi/responsive/footer.shtml") %>
-
     </div>
   </body>
 </html>

--- a/spec/support/api_mocks.rb
+++ b/spec/support/api_mocks.rb
@@ -10,12 +10,6 @@ module ApiMocks
     end
   end
 
-
-  def stub_ssi!
-    ApplicationController.any_instance.stub(:include_ssi).and_return("SSI INCLUDE!!!!")
-  end
-
-
   def turn_on_ldap!
     Rails.configuration.stub(:ldap_lookup_flag).and_return(true)
   end


### PR DESCRIPTION
There was a single page template that referenced the server side includes we had on the library site. 